### PR TITLE
add nginx resolver customization using environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
           path: ./build
           env: 
             API_ENDPOINT: https://api.run.pivotal.io
-  
+            # Use Google DNS by default
+            NGINX_RESOLVER: 8.8.8.8
+
 4\. Install npm packages: `npm install`<br\>  
 5\. Build the application using Grunt: `grunt build`<br\>  
 6\. Push this application to Cloud Foundry using the cf Command Line Interface (CLI): `cf push`.<br\>  

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
   path: ./build
   env: 
     API_ENDPOINT: https://api.run.pivotal.io
+    # Use Google DNS by default
+    NGINX_RESOLVER: 8.8.8.8

--- a/src/nginx.conf
+++ b/src/nginx.conf
@@ -28,7 +28,7 @@ http {
     listen <%= ENV["PORT"] %>;
 
     location /oauth {
-        resolver 8.8.8.8;
+        resolver <%= ENV["NGINX_RESOLVER"] %>;
         proxy_pass '${http_X_UAA_Endpoint}/oauth/token';
         proxy_set_header Content-Type 'application/x-www-form-urlencoded';
         proxy_set_header Authorization 'Basic Y2Y6';


### PR DESCRIPTION
Ngnix requires a resolver to locate UAA endpoint. On private CF instance it is not always available.