### PR TITLE
enforce https usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
           path: ./build
           env: 
             API_ENDPOINT: https://api.run.pivotal.io
+            #Enforce https is used (using x_forwarded_proto check) .Default: enabled
+            FORCE_HTTPS: 1
+
   
 4\. Install npm packages: `npm install`<br\>  
 5\. Build the application using Grunt: `grunt build`<br\>  

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
   path: ./build
   env: 
     API_ENDPOINT: https://api.run.pivotal.io
+    #Enforce https is used (using x_forwarded_proto check) .Default: enabled
+    FORCE_HTTPS: 1

--- a/src/nginx.conf
+++ b/src/nginx.conf
@@ -50,6 +50,11 @@ http {
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
       autoindex on;
       <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+       if ($http_x_forwarded_proto != "https") {
+         return 301 https://$host$request_uri;
+       }
+      <% end %>
     }
   }
 }


### PR DESCRIPTION
To avoid error 400 when http is use, force redirect to https