### PR TITLE
cope with cases where service metadata are missing (extra = null)

### DIFF
--- a/src/app/components/marketplace/marketplaceAddServiceCtrl.js
+++ b/src/app/components/marketplace/marketplaceAddServiceCtrl.js
@@ -61,13 +61,14 @@ angular.module('app.marketplace').controller('marketplaceAddServiceCtrl', ['$q',
 
       var objectService = {
         id: service.metadata.guid,
-        name: (extraData.displayName) ? extraData.displayName : service.entity.label,
+	//cope with cases where extraData is Null and avoid premature exit
+        name: (extraData && extraData.displayName) ? extraData.displayName : service.entity.label,
         description: service.entity.description,
-        longDescription: (extraData.longDescription) ? extraData.longDescription : service.entity.long_description,
-        provider: (extraData.providerDisplayName) ? extraData.providerDisplayName : service.entity.provider,
-        imageUrl: (extraData.imageUrl) ? extraData.imageUrl : null,
-        documentationUrl: (extraData.documentationUrl) ? extraData.documentationUrl : service.entity.documentation_url,
-        supportUrl: (extraData.supportUrl) ? extraData.supportUrl : null
+        longDescription: (extraData && extraData.longDescription) ? extraData.longDescription : service.entity.long_description,
+        provider: (extraData && extraData.providerDisplayName) ? extraData.providerDisplayName : service.entity.provider,
+        imageUrl: (extraData && extraData.imageUrl) ? extraData.imageUrl : null,
+        documentationUrl: (extraData && extraData.documentationUrl) ? extraData.documentationUrl : service.entity.documentation_url,
+        supportUrl: (extraData && extraData.supportUrl) ? extraData.supportUrl : null
       };
 
       $scope.services.push(objectService);
@@ -162,7 +163,7 @@ angular.module('app.marketplace').controller('marketplaceAddServiceCtrl', ['$q',
 
         // get costs
         var costs = null;
-        if (extraData.costs) {
+        if (extraData && extraData.costs) {
           var unit = extraData.costs[0].unit.replace('LY', '');
 
           var currency = null;
@@ -180,9 +181,9 @@ angular.module('app.marketplace').controller('marketplaceAddServiceCtrl', ['$q',
 
         var objectServicePlan = {
           id: servicePlan.metadata.guid,
-          name: (extraData.displayName) ? extraData.displayName : servicePlan.entity.name,
+          name: (extraData && extraData.displayName) ? extraData.displayName : servicePlan.entity.name,
           description: servicePlan.entity.description,
-          bullets: (extraData.bullets) ? extraData.bullets : null,
+          bullets: (extraData && extraData.bullets) ? extraData.bullets : null,
           costs: (servicePlan.entity.free) ? 'free' : costs
         };
 


### PR DESCRIPTION
Some service brokers lack the metadata.extra field in service offering. This breaks the cf-web-ui rendering, which then omits the corresponding marketplace service offering from the UI. This PR fix it.
