### PR TITLE
Enable ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: bash
+sudo: required
+services:
+  - docker
+before_script:
+  - cd ..
+script:
+  - chmod ugo+x cf-webui/ci/*.sh
+  - docker run -it -v $(pwd):/root/sources -w /root/sources node:6 cf-webui/ci/build.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+OUTPUT="$PWD/cf-webui-app"
+
+echo "DEBUG - OUTPUT: <$OUTPUT> - VERSION: <$VERSION>"
+mkdir -p $OUTPUT
+
+
+pushd cf-webui
+    npm install
+    npm install grunt-cli
+    export PATH=$PWD/node_modules/grunt-cli/bin:$PATH
+    grunt build
+    cp -R build/* $OUTPUT
+popd
+
+

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,8 +3,8 @@
 set -e
 OUTPUT="$PWD/cf-webui-app"
 
-echo "DEBUG - OUTPUT: <$OUTPUT> - VERSION: <$VERSION>"
-mkdir -p $OUTPUT
+echo "DEBUG - OUTPUT: <$OUTPUT>"
+mkdir -p $OUTPUT/build
 
 
 pushd cf-webui
@@ -12,7 +12,8 @@ pushd cf-webui
     npm install grunt-cli
     export PATH=$PWD/node_modules/grunt-cli/bin:$PATH
     grunt build
-    cp -R build/* $OUTPUT
+    cp -R build/* $OUTPUT/build
+    cp manifest.yml $OUTPUT/
 popd
 
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: node
+    tag: '6'
+
+inputs:
+- name: cf-webui
+
+outputs:
+- name: cf-webui-app
+
+run:
+  path: cf-webui/ci/build.sh

--- a/ci/pipeline/README.md
+++ b/ci/pipeline/README.md
@@ -1,0 +1,20 @@
+# CF-WebUi Concourse pipeline
+This directory contains a very simple integration pipeline for [Concourse CI](https://concourse.ci/).
+It is a one job pipeline (compilation and deployment to CF).
+
+## Pre-requisite
+ - a running concourse instance ([installing concourse ](https://concourse.ci/installing.html))
+ - a concourse CLI ([The Fly CLI](https://concourse.ci/fly-cli.html))
+
+## Install cf-web-ui pipeline
+ 1. update credentials-cf-webui-template.yml (at least with your CF info)
+ 1. push the pipeline from project root directory:
+    ```
+    fly -t <concourse-target> set-pipeline --config ci/pipeline/pipeline.yml --pipeline cf-webui -l ci/pipeline/credentials-cf-webui-template.yml
+    ```
+ 1. enable the pipeline
+    ```
+     fly -t <concourse-target> unpause-pipeline --pipeline cf-webui
+
+    ```
+

--- a/ci/pipeline/credentials-cf-webui-template.yml
+++ b/ci/pipeline/credentials-cf-webui-template.yml
@@ -1,0 +1,12 @@
+---
+cf-webui-git-url: https://github.com/icclab/cf-webui
+cf-webui-git-branch: master
+
+
+cf-api-endpoint: https://api.run.pivotal.io
+cf-username: <YOUR_CF_USER>
+cf-userpassword: <YOUR_CF_PASSWORD>
+cf-org: <YOUR_CF_ORG>
+cf-space: <YOUR_CF_SPACE>
+cf-skip-cert-check: false
+ngnix-resolver: 8.8.8.8

--- a/ci/pipeline/pipeline.yml
+++ b/ci/pipeline/pipeline.yml
@@ -1,0 +1,33 @@
+---
+resources:
+- name: cf-webui
+  type: git
+  source:
+    uri: {{cf-webui-git-url}}
+    branch: {{cf-webui-git-branch}}
+
+- name: resource-deploy-cf-webui
+  type: cf
+#https://github.com/concourse/cf-resource
+  source:
+    api: {{cf-api-endpoint}}
+    username: {{cf-username}}
+    password: {{cf-userpassword}}
+    organization: {{cf-org}}
+    space: {{cf-space}}
+    skip_cert_check: true
+
+jobs:
+- name: job-cf-webui
+  plan:
+  - get: cf-webui
+    trigger: true
+    attempts: 3
+  - task: build
+    file: cf-webui/ci/build.yml
+  - put: resource-deploy-cf-webui
+    params:
+      manifest: cf-webui-app/manifest.yml
+      environment_variables:
+        API_ENDPOINT: {{cf-api-endpoint}}
+        NGINX_RESOLVER: {{ngnix-resolver}}


### PR DESCRIPTION
This PR setup continuous integration for cf-webui. It's done for 2 different tools [Travis CI](https://travis-ci.org) and [Concourse CI](https://concourse.ci/).

To see how Travis looks like https://travis-ci.org/Orange-OpenSource/cf-webui. 
For concourse no public instance exists :disappointed: 